### PR TITLE
Iss#25

### DIFF
--- a/src/modules/Member/MemberController.js
+++ b/src/modules/Member/MemberController.js
@@ -22,7 +22,7 @@ module.exports = {
     async remove(req, res) {
         try {
             const removedMember = await remove(req.params.id);
-            return res.status(200).send({ member: removedMember, message: 'Membero removido com sucesso!' });
+            return res.status(200).send({ member: removedMember, message: 'Membro removido com sucesso!' });
         } catch (error) {
             return res.status(500).send({ error: error.message });
         }

--- a/src/modules/Member/MemberService.js
+++ b/src/modules/Member/MemberService.js
@@ -17,12 +17,14 @@ module.exports = {
       department,
     } = memberData;
 
+    verifyEmail(memberData.email);
+    
     const psw = await bcrypt.hash(
       `${password}`,
       parseInt(process.env.SALT_ROUNDS)
     );
 
-    const member = await Member.create({
+    const newMember = await Member.create({
       name,
       email,
       role,
@@ -36,7 +38,7 @@ module.exports = {
       department,
     });
 
-    return getDTOmember(member);
+    return getDTOmember(newMember);
   },
 
   // only for test purposes
@@ -72,6 +74,14 @@ module.exports = {
 
     return getDTOmember(updatedMember);
   },
+};
+
+function verifyEmail(email) {
+  const member = Member.findOne({ email: email });
+
+  if (member) {
+    return { message: 'Já existe um membro cadastrado para esse email!' };
+  }
 };
 
 function getDTOmember(member) {

--- a/src/modules/Member/MemberService.js
+++ b/src/modules/Member/MemberService.js
@@ -17,7 +17,7 @@ module.exports = {
       department,
     } = memberData;
 
-    const emailInUse = await verifyEmail(email);
+    const emailInUse = await isEmailInUse(email);
     if (emailInUse) {
       throw new Error('Já existe um membro cadastrado para esse email!');
     }
@@ -79,9 +79,10 @@ module.exports = {
   },
 };
 
-async function verifyEmail(memberEmail) {
-  return await Member.findOne({ email: memberEmail });;
-};
+async function isEmailInUse(memberEmail) {
+  const emailInUse = await Member.findOne({ email: memberEmail });
+  return emailInUse !== null;
+}
 
 function getDTOmember(member) {
   return {

--- a/src/modules/Member/MemberService.js
+++ b/src/modules/Member/MemberService.js
@@ -17,7 +17,10 @@ module.exports = {
       department,
     } = memberData;
 
-    verifyEmail(memberData.email);
+    const emailInUse = await verifyEmail(email);
+    if (emailInUse) {
+      throw new Error('Já existe um membro cadastrado para esse email!');
+    }
 
     const psw = await bcrypt.hash(
       `${password}`,
@@ -76,11 +79,8 @@ module.exports = {
   },
 };
 
-function verifyEmail(memberEmail) {
-  const member = Member.findOne({ email: memberEmail });
-
-  if (member) 
-    throw new Error('Já existe um usuário cadastrado para esse email!');
+async function verifyEmail(memberEmail) {
+  return await Member.findOne({ email: memberEmail });;
 };
 
 function getDTOmember(member) {

--- a/src/modules/Member/MemberService.js
+++ b/src/modules/Member/MemberService.js
@@ -18,7 +18,7 @@ module.exports = {
     } = memberData;
 
     verifyEmail(memberData.email);
-    
+
     const psw = await bcrypt.hash(
       `${password}`,
       parseInt(process.env.SALT_ROUNDS)
@@ -76,12 +76,11 @@ module.exports = {
   },
 };
 
-function verifyEmail(email) {
-  const member = Member.findOne({ email: email });
+function verifyEmail(memberEmail) {
+  const member = Member.findOne({ email: memberEmail });
 
-  if (member) {
-    return { message: 'Já existe um membro cadastrado para esse email!' };
-  }
+  if (member) 
+    throw new Error('Já existe um usuário cadastrado para esse email!');
 };
 
 function getDTOmember(member) {


### PR DESCRIPTION
Agora não é permitida a adição de um membro utilizando um email já em uso. Por exemplo, eu tenho minha conta para o email "anaritamed@gmail.com":
![image](https://github.com/codexjr-dev/dashboard-codex-api/assets/100716949/2d2d9d67-59fe-48ab-9f9b-597d091fb5b2)

E tento adicionar um outro membro com esse mesmo email:
![image](https://github.com/codexjr-dev/dashboard-codex-api/assets/100716949/584d66ce-1f9b-4887-97c1-ee7b9342def2)
É lançado um erro ao tentar adicionar.

O mesmo ocorre para quando editado o campo email e inserido um email já em uso:
![image](https://github.com/codexjr-dev/dashboard-codex-api/assets/100716949/0d99cf6d-8b44-4567-b062-b1a1005026e2)
